### PR TITLE
work on fdw python test script

### DIFF
--- a/sql/aspirin_fdw.sql
+++ b/sql/aspirin_fdw.sql
@@ -13,7 +13,7 @@ WITH medications_all AS (
 ),
 
 diagnoses_all AS (
-	SELECT patient_id FROM vdb1_diagnoses where year = {0}
+	SELECT patient_id FROM vdb1_diagnoses where year = {0} -- and where diag_src = 'hd'
 	UNION ALL
 	SELECT patient_id FROM vdb2_diagnoses where year = {0}
 	UNION ALL

--- a/sql/fdw_test.py
+++ b/sql/fdw_test.py
@@ -97,10 +97,11 @@ def run_test(num_machines, num_runs,query_function, year):
     query = query_function(num_machines, year)
     for i in range(num_runs):
         c = cur.execute(query)
-    time_values.pop(0) # remove the first one b/c takes a long time
+    time_values.remove(max(time_values))
+    time_values.remove(min(time_values))
     avg = statistics.mean(time_values)
     standard_dev = statistics.stdev(time_values)
-    print("removed first timed run")
+    print("removed longest and shortest timed runs")
     print("the average is: " + str(avg))
     print("the stdev is: " + str(standard_dev))
 
@@ -110,9 +111,10 @@ search_year = str(sys.argv[3])
 if num_machines < 1 or num_machines > 4:
     print("MUST RUN ON AT LEAST ONE MACHINE AND NOT MORE THAN 4")
     sys.exit()
-if num_runs < 3:
-    print("must run atleast 3 runs")
+if num_runs < 4:
+    print("must run atleast 4 runs (for std dev)")
     sys.exit()
+
 print("ASPIRIN TEST")
 time_values = []
 run_test(num_machines, num_runs, make_asprin_query, search_year)


### PR DESCRIPTION
* python fdw_test.py NUM_MACHINES NUM_RUNS YEAR
must run this on vaultdb04

* Aspirin test goes first takes a long time

* For mean/std deviation i removed the first test run from the timing list (line 100) Not sure if you said also to remove the last? or remove highest/lowest, trivial python stuff....

* Hard coded the aspirin sql, based on way i did it, it would have just taken a little bit more work to script it up, but it works, but is hard coded to do all 4 machines. Modify that sql file (or make a new one) to have it work on less machines. The script reads in that file as opposed to building the query internally like the other 2 tests. 

* Also I didn't filter the di.diag_src because 'hd' wasn't right and was just returning 0 tuples. to fix just add in the wheres for the diagnoses_all table "and diag_src = 'hd'" or whatever else.  